### PR TITLE
Add `renter_subletter_cannot_be_same` validation to the `Contract` model

### DIFF
--- a/storeshare_api/app/models/contract.rb
+++ b/storeshare_api/app/models/contract.rb
@@ -22,6 +22,7 @@ class Contract < ApplicationRecord
 
   def renter_subletter_cannot_be_same
     # compare user_id of the renter and subletter
+    return unless renter_id.present? && subletter_id.present?
     return unless Renter.find(renter_id).user_id == Subletter.find(subletter_id).user_id
 
     errors.add(:renter_id, 'cannot belong to the same user as the subletter')

--- a/storeshare_api/app/models/contract.rb
+++ b/storeshare_api/app/models/contract.rb
@@ -10,6 +10,7 @@ class Contract < ApplicationRecord
   validates :start_date, :renter_id, :subletter_id, :listing_id, :price, presence: true
   validate :start_date_cannot_be_in_the_past
   validates :end_date, date: { after_or_equal_to: :start_date }, presence: true
+  validate :renter_subletter_cannot_be_same, on: :create
 
   private
 
@@ -17,5 +18,12 @@ class Contract < ApplicationRecord
     return unless start_date.present? && start_date < Date.today
 
     errors.add(:start_date, 'cannot be in the past')
+  end
+
+  def renter_subletter_cannot_be_same
+    # compare user_id of the renter and subletter
+    return unless Renter.find(renter_id).user_id == Subletter.find(subletter_id).user_id
+
+    errors.add(:renter_id, 'cannot be the same as subletter_id')
   end
 end

--- a/storeshare_api/app/models/contract.rb
+++ b/storeshare_api/app/models/contract.rb
@@ -24,6 +24,6 @@ class Contract < ApplicationRecord
     # compare user_id of the renter and subletter
     return unless Renter.find(renter_id).user_id == Subletter.find(subletter_id).user_id
 
-    errors.add(:renter_id, 'cannot be the same as subletter_id')
+    errors.add(:renter_id, 'cannot belong to the same user as the subletter')
   end
 end

--- a/storeshare_api/spec/models/contract_spec.rb
+++ b/storeshare_api/spec/models/contract_spec.rb
@@ -22,6 +22,15 @@ RSpec.describe Contract, type: :model do
       contract.valid?
       expect(contract.errors[:end_date]).to include("must be after or equal to #{contract.start_date}")
     end
+
+    it 'should validate that the renter and subletter are not the same user' do
+      user = FactoryBot.create(:user)
+      renter = FactoryBot.create(:renter, user:)
+      subletter = FactoryBot.create(:subletter, user:)
+      contract = Contract.new(renter:, subletter:)
+      contract.valid?
+      expect(contract.errors[:renter_id]).to include('cannot belong to the same user as the subletter')
+    end
   end
 
   describe 'associations' do


### PR DESCRIPTION
preventing a renter to lease a listing that they own